### PR TITLE
feat: Add user's name to dashboard page title

### DIFF
--- a/app/dashboard/dashboard-content.tsx
+++ b/app/dashboard/dashboard-content.tsx
@@ -52,9 +52,10 @@ type DashboardContentProps = {
   workouts: Workout[];
   selectedDate: Date;
   workoutDates: Date[];
+  userFirstName: string;
 };
 
-export default function DashboardContent({ workouts, selectedDate, workoutDates }: DashboardContentProps) {
+export default function DashboardContent({ workouts, selectedDate, workoutDates, userFirstName }: DashboardContentProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [openWorkoutId, setOpenWorkoutId] = useState<number | null>(null);
@@ -76,7 +77,7 @@ export default function DashboardContent({ workouts, selectedDate, workoutDates 
     <div className="container mx-auto px-4 py-8 max-w-4xl" suppressHydrationWarning>
       {/* Header Section */}
       <div className="flex items-center justify-between mb-8">
-        <h1 className="text-3xl font-bold">Workout Dashboard</h1>
+        <h1 className="text-3xl font-bold">{userFirstName}&apos;s lifting diary</h1>
 
         <div className="flex items-center gap-4">
           {/* Date Picker */}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,5 +1,6 @@
 import { getWorkoutsByDate, getWorkoutDatesForMonth } from '@/data/workouts';
 import { parseDateFromDb } from '@/lib/date-utils';
+import { currentUser } from '@clerk/nextjs/server';
 import DashboardContent from './dashboard-content';
 
 type PageProps = {
@@ -23,11 +24,16 @@ export default async function DashboardPage({ searchParams }: PageProps) {
     selectedDate.getMonth()
   );
 
+  // Fetch user's first name from Clerk (follows auth.md standards)
+  const user = await currentUser();
+  const userFirstName = user?.firstName || 'Your';
+
   return (
     <DashboardContent
       workouts={workouts}
       selectedDate={selectedDate}
       workoutDates={workoutDates}
+      userFirstName={userFirstName}
     />
   );
 }


### PR DESCRIPTION
Updated the dashboard page to display the user's first name in the title, showing [FirstName]'s lifting diary instead of Workout Dashboard.

Fixes #5